### PR TITLE
Add automatic pool creation and mirror setup

### DIFF
--- a/src/layer.yaml
+++ b/src/layer.yaml
@@ -1,4 +1,5 @@
 includes:
+  - layer:leadership
   - layer:ceph
   - interface:ceph-rbd-mirror
   - interface:nrpe-external-master

--- a/src/lib/charm/openstack/ceph_rbd_mirror.py
+++ b/src/lib/charm/openstack/ceph_rbd_mirror.py
@@ -12,8 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import socket
+import subprocess
+
 import charms_openstack.charm
 import charms_openstack.adapters
+
+# import charmhelpers.core.host as ch_host
+
+
+class CephRBDMirrorCharmRelationAdapters(
+        charms_openstack.adapters.OpenStackRelationAdapters):
+    relation_adapters = {
+        'ceph_local': charms_openstack.adapters.CephRelationAdapter,
+        'ceph_remote': charms_openstack.adapters.CephRelationAdapter,
+    }
 
 
 class CephRBDMirrorCharm(charms_openstack.charm.CephCharm):
@@ -21,19 +34,51 @@ class CephRBDMirrorCharm(charms_openstack.charm.CephCharm):
     # rbd-mirror daemon.  Luminous appears in UCA at pike.
     release = 'pike'
     name = 'ceph-rbd-mirror'
-    packages = ['rbd-mirror']
     python_version = 3
+    packages = ['rbd-mirror']
     required_relations = ['ceph-local', 'ceph-remote']
+    user = 'ceph'
+    group = 'ceph'
+    adapters_class = CephRBDMirrorCharmRelationAdapters
+    ceph_service_name_override = 'rbd-mirror'
+    ceph_key_per_unit_name = True
 
-    def config_changed(self):
-        """Check for upgrade."""
-        self.upgrade_if_available(None)
+    def __init__(self, **kwargs):
+        self.ceph_id = 'rbd-mirror.{}'.format(socket.gethostname())
+        self.services = [
+            'ceph-rbd-mirror@{}'.format(self.ceph_id),
+        ]
+        self.restart_map = {
+            '/etc/ceph/ceph.conf': self.services,
+            '/etc/ceph/remote.conf': self.services,
+        }
+        super().__init__(**kwargs)
 
-    def install(self):
-        """We override install function to configure source before installing
-        packages.
+    def _mirror_pool_info(self, pool):
+        output = subprocess.check_output(['rbd', '--id', self.ceph_id,
+                                          'mirror', 'pool', 'info', pool],
+                                         universal_newlines=True)
+        return output
 
-        The OpenStackAPICharm class already does this but we do not need nor
-        want the other services it provides for Ceph charms."""
-        self.configure_source()
-        super().install()
+    def mirror_pool_enabled(self, pool):
+        return 'Mode: pool' in self._mirror_pool_info(pool)
+
+    def mirror_pool_has_peers(self, pool):
+        return 'Peers: none' not in self._mirror_pool_info(pool)
+
+    def mirror_pool_status(self, pool):
+        output = subprocess.check_output(['rbd', '--id', self.ceph_id,
+                                          'mirror', 'pool', 'status', pool],
+                                         universal_newlines=True)
+        result = {}
+        for line in output.splitlines():
+            vp = line.split(':')
+            result.update(vp[0], vp[1].lstrip().rstrip())
+        return result
+
+    def mirror_pool_enable(self, pool):
+        base_cmd = ['rbd', '--id', self.ceph_id, 'mirror', 'pool']
+        subprocess.check_call(base_cmd + ['enable', pool, 'pool'])
+        subprocess.check_call(base_cmd + ['peer', 'add', pool,
+                                          'client.{}@remote'
+                                          .format(self.ceph_id)])

--- a/src/reactive/ceph_rbd_mirror_handlers.py
+++ b/src/reactive/ceph_rbd_mirror_handlers.py
@@ -25,39 +25,79 @@ charms_openstack.bus.discover()
 # Use the charms.openstack defaults for common states and hooks
 charm.use_defaults(
     'charm.installed',
-    'config.changed',
     'update-status',
     'upgrade-charm')
 
 
 @reactive.when_all('ceph-local.connected', 'ceph-remote.connected')
 @reactive.when_not_all('ceph-local.available', 'ceph-remote.available')
-def ceph_connected():
-    for flag in ('ceph-local.connected', 'ceph-remote.connected'):
-        endpoint = reactive.relations.endpoint_from_flag(flag)
-        endpoint.request_key()
-
+def request_keys():
     with charm.provide_charm_instance() as charm_instance:
-        ch_core.hookenv.log('Ceph connected, charm_instance @ {}'
-                            .format(charm_instance),
-                            level=ch_core.hookenv.DEBUG)
+        for flag in ('ceph-local.connected', 'ceph-remote.connected'):
+            endpoint = reactive.relations.endpoint_from_flag(flag)
+            ch_core.hookenv.log('Ceph endpoint "{}" connected, requesting key'
+                                .format(endpoint.endpoint_name),
+                                level=ch_core.hookenv.INFO)
+            endpoint.request_key()
+            charm_instance.assess_status()
+
+
+@reactive.when('config.changed')
+@reactive.when('ceph-local.available')
+@reactive.when('ceph-remote.available')
+def config_changed():
+    with charm.provide_charm_instance() as charm_instance:
+        charm_instance.upgrade_if_available([
+            reactive.relations.endpoint_from_flag('ceph-local.available'),
+            reactive.relations.endpoint_from_flag('ceph-remote.available'),
+        ])
         charm_instance.assess_status()
 
 
-@reactive.when_all('ceph-local.available', 'ceph-remote.available')
-def ceph_available():
-    mon_hosts = {}
-    for flag in ('ceph-local.available', 'ceph-remote.available'):
-        endpoint = reactive.relations.endpoint_from_flag(flag)
-        mon_hosts[endpoint.endpoint_name] = endpoint.mon_hosts
-        for relation in endpoint.relations:
-            for unit in relation.units:
-                ch_core.hookenv.log('{}: "{}"'.format(flag, unit.received),
-                                    level=ch_core.hookenv.INFO)
-
+@reactive.when_not('config.rendered')
+def disable_services():
     with charm.provide_charm_instance() as charm_instance:
-        ch_core.hookenv.log('Ceph available, mon_hosts: "{}" '
-                            'charm_instance @ {}'
-                            .format(mon_hosts, charm_instance),
-                            level=ch_core.hookenv.DEBUG)
+        for service in charm_instance.services:
+            ch_core.host.service('disable', service)
+            ch_core.host.service('stop', service)
+
+
+@reactive.when('ceph-local.available')
+@reactive.when('ceph-remote.available')
+def render_stuff(*args):
+    with charm.provide_charm_instance() as charm_instance:
+        for endpoint in args:
+            ch_core.hookenv.log('Ceph endpoint "{}" available, configuring '
+                                'keyring'.format(endpoint.endpoint_name),
+                                level=ch_core.hookenv.INFO)
+            ch_core.hookenv.log('Pools: "{}"'.format(endpoint.pools),
+                                level=ch_core.hookenv.INFO)
+
+            cluster_name = (
+                'remote') if endpoint.endpoint_name == 'ceph-remote' else None
+            charm_instance.configure_ceph_keyring(endpoint,
+                                                  cluster_name=cluster_name)
+        charm_instance.render_with_interfaces(args)
+        with charm.provide_charm_instance() as charm_instance:
+            for service in charm_instance.services:
+                ch_core.host.service('enable', service)
+                ch_core.host.service('start', service)
+        reactive.set_flag('config.rendered')
         charm_instance.assess_status()
+
+
+@reactive.when('leadership.is_leader')
+@reactive.when('config.rendered')
+@reactive.when('ceph-local.available')
+@reactive.when('ceph-remote.available')
+def configure_pools():
+    local = reactive.endpoint_from_flag('ceph-local.available')
+    remote = reactive.endpoint_from_flag('ceph-remote.available')
+    with charm.provide_charm_instance() as charm_instance:
+        for pool, attrs in local.pools.items():
+            if 'rbd' in attrs['applications']:
+                if not (charm_instance.mirror_pool_enabled(pool) and
+                        charm_instance.mirror_pool_has_peers(pool)):
+                    # TODO(fnordahl) add rest of attrs when creating pool
+                    remote.create_pool(pool, app_name='rbd')
+                    charm_instance.mirror_pool_enable(pool)

--- a/src/templates/ceph.conf
+++ b/src/templates/ceph.conf
@@ -1,0 +1,21 @@
+###############################################################################
+# [ WARNING ]
+# cinder configuration file maintained by Juju
+# local changes may be overwritten.
+###############################################################################
+[global]
+{% if ceph_local.auth -%}
+auth_supported = {{ ceph_local.auth }}
+keyring = /etc/ceph/$cluster.$name.keyring
+mon host = {{ ceph_local.monitors }}
+{% endif -%}
+log to syslog = {{ use_syslog }}
+err to syslog = {{ use_syslog }}
+clog to syslog = {{ use_syslog }}
+
+[client]
+{% if rbd_client_cache_settings -%}
+{% for key, value in rbd_client_cache_settings.items() -%}
+{{ key }} = {{ value }}
+{% endfor -%}
+{%- endif %}

--- a/src/templates/remote.conf
+++ b/src/templates/remote.conf
@@ -1,0 +1,21 @@
+###############################################################################
+# [ WARNING ]
+# cinder configuration file maintained by Juju
+# local changes may be overwritten.
+###############################################################################
+[global]
+{% if ceph_remote.auth -%}
+auth_supported = {{ ceph_remote.auth }}
+keyring = /etc/ceph/$cluster.$name.keyring
+mon host = {{ ceph_remote.monitors }}
+{% endif -%}
+log to syslog = {{ use_syslog }}
+err to syslog = {{ use_syslog }}
+clog to syslog = {{ use_syslog }}
+
+[client]
+{% if rbd_client_cache_settings -%}
+{% for key, value in rbd_client_cache_settings.items() -%}
+{{ key }} = {{ value }}
+{% endfor -%}
+{%- endif %}

--- a/src/tests/bundles/bionic-queens.yaml
+++ b/src/tests/bundles/bionic-queens.yaml
@@ -1,5 +1,20 @@
 series: bionic
 applications:
+  mysql:
+    charm: cs:~openstack-charmers-next/percona-cluster
+    num_units: 1
+  keystone:
+    charm: cs:~openstack-charmers-next/keystone
+    num_units: 1
+  rabbitmq-server:
+    charm: cs:~openstack-charmers-next/rabbitmq-server
+    num_units: 1
+  cinder:
+    charm: cs:~openstack-charmers-next/cinder
+    num_units: 1
+  cinder-ceph:
+    charm: cs:~openstack-charmers-next/cinder-ceph
+    num_units: 0
   ceph-mon:
     charm: cs:~fnordahl/ceph-mon-rbd-mirror
     num_units: 3
@@ -39,6 +54,18 @@ applications:
     options:
       source: distro
 relations:
+- - mysql
+  - keystone
+- - mysql
+  - cinder
+- - rabbitmq-server
+  - cinder
+- - keystone
+  - cinder
+- - cinder
+  - cinder-ceph
+- - cinder-ceph
+  - ceph-mon
 - - ceph-mon:osd
   - ceph-osd:mon
 - - ceph-mon


### PR DESCRIPTION
Pools with application ``rbd`` are automatically created on the remote end.

Mirroring is also automatically configured for these pools in both ends.

Implement leadership tracking to allow multiple units to run.

Delay startup of service until configuration and keys are ready.